### PR TITLE
If route value isn't regex/function, this.add(key)

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,12 @@ function Ramrod( routes ){
 
         if( util.isRegExp( routes[path] ) ){
           this.routes[path] = routes[path];
-        }
 
-        if( typeof routes[path] == "function" ){
+        } else if( typeof routes[path] == "function" ){
           this.add( path, routes[path] );
+
+        } else {
+          this.add( path );
         }
 
       }

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,14 @@ describe('Router', function(){
       router.dispatch({ url: '/foo'});
       router.dispatch({ url: '/bar'});
     });
+
+    it('if route value is not regex or function, this.add(key)', function () {
+      var router = ramrod({
+        'foo/:bar': null
+      });
+
+      assert.ok( router.routes['foo/:bar'] );
+    });
   });
 
   describe('add', function(){


### PR DESCRIPTION
This is an awesome project, I'm glad I found it before I wrote my own.

I really like being able to specify my routes when I create the router, and then listen to the events whenever I feel like it.  This is just a quick patch so that I can do that for all routes, even if I don't want to write the regex by hand, and don't have enough information to create the handler function (or just want it grouped with the other listeners.)
