### PR TITLE
Add support for additional characters in the URL, as supported by RFC 1738.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var parseQuerystring = require('querystring').parse;
 
 var namedParam    = /:\w+/g;
 var splatParam    = /\*\w+/g;
-var escapeRegExp  = /[-[\]{}()+?.,\\^$|#\s]/g;
-var namespaced    = /^[\w\/:]+\|(\w+)$/;
+var escapeRegExp  = /[-[\]{}()+?.,\\^$|#\s*]/g;
+var namespaced    = /^[\w\/:$\-_.+!*(),]+\|(\w+)$/;
 
 function Ramrod( routes ){
   this.routes = {};

--- a/test/index.js
+++ b/test/index.js
@@ -217,5 +217,27 @@ describe('Integration', function(){
 
   });
 
+  // RFC1738 defines the following characters as valid unencoded characters in a url.
+  // http://www.faqs.org/rfcs/rfc1738.html
+  '$-_.+!*(),'.split('').forEach(function(character){
+    router.post('path/with/char'+character, function(req, res){
+      res.writeHead(405);
+      res.end('Not Allowed');
+    });
+
+    router.get('path/with/char'+character, function(req, res){
+      res.writeHead(200);
+      res.end('char'+character);
+    });
+
+    it('router#'+character, function(done){
+      request.get('http://localhost:9999/path/with/char'+character, function(err, res, body){
+        assert.equal(res.statusCode, 200);
+        assert.equal(body, 'char'+character);
+        done();
+      });
+    });
+  });
+
 });
 


### PR DESCRIPTION
Ran into a bug with dashes in URLs.  For example, if you mapped the following two routes:

```
router.get('/path/with-dash', function(req, res) { ... });

router.post('/path/with-dash', function(req, res) { ... });
```

It would always route requests to the first route that matched the request url and would ignore the method constraint because the regexp that parses the route name would fail if it contained a character other than the set `[\w\/:]`.

RFC 1738 defines the following characters as valid within a URL:

`$-_.+!*'(),`

You'll notice this still doesn't support the `'` (single-quote).  That is because Node encodes the single-quote as `%27` so the regexp won't match it.  It might be a good idea to decode URLs before matching them against the regexp, but that's a larger change.
